### PR TITLE
[lib]: add null check to loadElement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toppings",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toppings",
-      "version": "1.0.0",
+      "version": "1.0.4",
       "license": "GPL-3.0",
       "dependencies": {
         "blendora": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toppings",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Toppings adds an extra layer of flavor for a more efficient and convenient web.",
   "private": "true",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Toppings",
   "short_name": "Toppings",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Toppings adds an extra layer of flavor for a more efficient and convenient web.",
   "homepage_url": "https://www.grabtoppings.xyz",
   "author": "Enrich Platforms",

--- a/src/scripts/lib/loadElement.ts
+++ b/src/scripts/lib/loadElement.ts
@@ -15,7 +15,7 @@ const loadElement = async (
   return await new Promise<HTMLElement>((resolve, reject) => {
     const checkInterval = setInterval(() => {
       const element = document.querySelector(selector) as HTMLElement
-      if (element !== undefined) {
+      if (element !== undefined && element !== null) {
         clearInterval(checkInterval)
         clearTimeout(checkTimeout)
         resolve(element)


### PR DESCRIPTION
**Description**

This pull request addresses the issue of `loadElement` resolving with `null` when the element is not found. It modifies the `loadElement` function to handle the `null` return value correctly.

**Changes Made**

- Modified the `loadElement` function to correctly handle the case when `document.querySelector` returns `null`.

Closes: #11 