### PR TITLE
[lib]: loadElement should fail silently

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "toppings",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toppings",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "GPL-3.0",
       "dependencies": {
         "blendora": "^2.0.0"
       },
       "devDependencies": {
-        "@types/node": "^20.5.9",
+        "@types/node": "^20.8.9",
         "@typescript-eslint/eslint-plugin": "^6.6.0",
         "@typescript-eslint/parser": "^6.6.0",
         "archiver": "^6.0.1",
@@ -342,10 +342,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
-      "dev": true
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
+      "integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.1",
@@ -4840,6 +4843,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": "true",
   "scripts": {
     "build:dev": "webpack --watch --config webpack.config.dev.js",
-    "build:prod": "webpack --mode production --config webpack.config.js",
-    "build:release": "npm run build:prod && node scripts/release.js",
+    "build:prod": "webpack --watch",
+    "build:release": "webpack && node scripts/release.js",
     "lint": "eslint . --ext .ts --config .eslintrc.json --fix",
     "type-check": "tsc --noEmit",
     "test": "npm run lint && npm run type-check"
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/enrich-platforms/toppings#readme",
   "devDependencies": {
-    "@types/node": "^20.5.9",
+    "@types/node": "^20.8.9",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "@typescript-eslint/parser": "^6.6.0",
     "archiver": "^6.0.1",

--- a/src/scripts/interfaces.ts
+++ b/src/scripts/interfaces.ts
@@ -40,3 +40,5 @@ export interface FetchToppingsAPIRequest {
     queryParams?: Record<string, string | null>
   }
 }
+
+export type Nullable<T> = T | null

--- a/src/scripts/lib/loadElement.ts
+++ b/src/scripts/lib/loadElement.ts
@@ -1,3 +1,5 @@
+import { type Nullable } from '../interfaces'
+
 /**
  * Asynchronously loads an element with the specified selector within a timeout.
  *
@@ -5,17 +7,17 @@
  * @param {number} timeout - The maximum time (in milliseconds) to wait for the element to appear.
  * @param {number} interval - The polling interval (in milliseconds) to check for the element.
  * @returns {Promise<HTMLElement>} - A promise that resolves to the loaded element.
- * @throws {Error} - Throws an error if the element is not found within the specified timeout.
+ * @throws {Error} - Throws an error if the element is not found within the specified timeout (in development mode).
  */
 const loadElement = async (
   selector: string,
   timeout: number,
   interval: number
-): Promise<HTMLElement> => {
-  return await new Promise<HTMLElement>((resolve, reject) => {
+): Promise<Nullable<HTMLElement>> => {
+  return await new Promise<Nullable<HTMLElement>>((resolve, reject) => {
     const checkInterval = setInterval(() => {
       const element = document.querySelector(selector) as HTMLElement
-      if (element !== undefined) {
+      if (element !== null) {
         clearInterval(checkInterval)
         clearTimeout(checkTimeout)
         resolve(element)
@@ -24,7 +26,11 @@ const loadElement = async (
 
     const checkTimeout = setTimeout(() => {
       clearInterval(checkInterval)
-      reject(new Error(`Element with selector '${selector}' not found within ${timeout}ms.`))
+      if (process.env.NODE_ENV === 'development') {
+        const errorMessage = `Element with selector '${selector}' not found within ${timeout}ms.`
+        console.warn(errorMessage)
+      }
+      resolve(null)
     }, timeout)
   })
 }

--- a/src/scripts/youtube/routeType/watch/main.ts
+++ b/src/scripts/youtube/routeType/watch/main.ts
@@ -1,5 +1,6 @@
 import { YTPlayer, createMenuItem } from 'blendora'
 import loadElement from '../../../lib/loadElement'
+import { type Nullable } from '../../../interfaces'
 
 let toggleSpeedShortcut: string
 let seekBackwardShortcut: string
@@ -51,33 +52,33 @@ chrome.storage.sync.get(
 )
 
 let currentSpeed: string
-let doubleTapSeekElement: HTMLElement
-let player: YTPlayer
-let playerSettingsButton: HTMLElement
-let playerPlaybackButton: HTMLElement
+let doubleTapSeekElement: Nullable<HTMLElement>
+let player: Nullable<YTPlayer>
+let playerSettingsButton: Nullable<HTMLElement>
+let playerPlaybackButton: Nullable<HTMLElement>
 let customSpeed: string
 let customSpeedButton: HTMLElement
-let doubleTapSeekTimeout: number
+let doubleTapSeekTimeout: ReturnType<typeof setTimeout>
 
 const onWatchPage = async (contentID: string): Promise<void> => {
-  try {
-    player = player ?? await loadPlayer(contentID)
+  player = await loadPlayer(contentID)
+  if (player !== null) {
     setWatchDefaults()
 
-    doubleTapSeekElement = doubleTapSeekElement ?? document.querySelector('.ytp-doubletap-ui-legacy') as HTMLElement
+    doubleTapSeekElement = document.querySelector('.ytp-doubletap-ui-legacy')
 
-    playerSettingsButton = playerSettingsButton ?? await loadSettingsBtn()
+    playerSettingsButton = await loadSettingsBtn()
     document.addEventListener('keydown', useShortcuts)
-    playerSettingsButton.removeEventListener('click', onSettingsMenu)
-    playerSettingsButton.addEventListener('click', onSettingsMenu, { once: true })
-  } catch (error) {
-    console.error('Failed to successfully load WatchPage:', error)
+    if (playerSettingsButton !== null) {
+      playerSettingsButton.removeEventListener('click', onSettingsMenu)
+      playerSettingsButton.addEventListener('click', onSettingsMenu, { once: true })
+    }
   }
 }
 
 const setWatchDefaults = (): void => {
-  currentSpeed = Number(defaultSpeed).toFixed(2)
-  player.setPlaybackSpeed(parseFloat(defaultSpeed))
+  currentSpeed = Number(defaultSpeed).toFixed(2);
+  (player as YTPlayer).setPlaybackSpeed(parseFloat(defaultSpeed))
 
   const labels = document.querySelectorAll('.ytp-menuitem-label')
   if (labels.length === 0) {
@@ -101,45 +102,38 @@ const setWatchDefaults = (): void => {
   }
 }
 
-const loadPlayer = async (contentID: string): Promise<YTPlayer> => {
-  try {
-    const playerVideoElement = await loadElement('video', 10000, 500) as HTMLVideoElement
+const loadPlayer = async (contentID: string): Promise<Nullable<YTPlayer>> => {
+  const playerVideoElement = await loadElement('video', 10000, 500) as Nullable<HTMLVideoElement>
+  if (playerVideoElement !== null) {
     const loadedPlayer = new YTPlayer(playerVideoElement, { videoID: contentID })
     return loadedPlayer
-  } catch (error) {
-    console.error('Failed to load player:', error)
-    throw error
   }
+  return null
 }
 
-const loadSettingsBtn = async (): Promise<HTMLElement> => {
-  try {
-    const playerSettingsButton = await loadElement('.ytp-settings-button', 10000, 500)
-    return playerSettingsButton
-  } catch (error) {
-    console.error('Failed to load settings button:', error)
-    throw error
-  }
+const loadSettingsBtn = async (): Promise<Nullable<HTMLElement>> => {
+  const playerSettingsButton = await loadElement('.ytp-settings-button', 10000, 500)
+  return playerSettingsButton
 }
 
 const onSettingsMenu = (): void => {
-  loadPlaybackSpeedBtn().then(button => {
+  void loadPlaybackSpeedBtn().then(button => {
     playerPlaybackButton = button
-    playerPlaybackButton.children[2].textContent =
+    if (playerPlaybackButton !== null) {
+      playerPlaybackButton.children[2].textContent =
     currentSpeed === '1' || currentSpeed === '1.00'
       ? 'Normal'
       : `${Number(currentSpeed)}`
-    playerPlaybackButton.addEventListener(
-      'click',
-      onPlaybackSpeedMenu
-    )
-  }).catch((error) => {
-    console.error('Failed to load playback speed button:', error)
+      playerPlaybackButton.addEventListener(
+        'click',
+        onPlaybackSpeedMenu
+      )
+    }
   })
 }
 
-const loadPlaybackSpeedBtn = async (): Promise<HTMLElement> => {
-  return await new Promise<HTMLElement>((resolve, reject) => {
+const loadPlaybackSpeedBtn = async (): Promise<Nullable<HTMLElement>> => {
+  return await new Promise<Nullable<HTMLElement>>((resolve, reject) => {
     const checkInterval = setInterval(() => {
       const labels = document.querySelectorAll('.ytp-menuitem-label')
       if (labels.length === 0) {
@@ -153,73 +147,73 @@ const loadPlaybackSpeedBtn = async (): Promise<HTMLElement> => {
           clearInterval(checkInterval)
           clearTimeout(checkTimeout)
           resolve(playerSettingsButton)
-          return
         }
       }
     }, 200)
 
     const checkTimeout = setTimeout(() => {
       clearInterval(checkInterval)
-      reject(new Error('Playback speed button not found within 2000ms.'))
+      if (process.env.NODE_ENV === 'development') {
+        const errorMessage = 'Playback speed button not found within 2000ms.'
+        console.warn(errorMessage)
+      }
+      resolve(null)
     }, 2000)
   })
 }
 
 const onPlaybackSpeedMenu = (): void => {
-  loadPlaybackSpeedMenu().then(firstMenuItemLabel => {
-    const menuPanelOptions = document.getElementsByClassName('ytp-panel-options')[0] as HTMLElement
-    menuPanelOptions.style.display = 'none'
+  void loadPlaybackSpeedMenu().then(firstMenuItemLabel => {
+    if (firstMenuItemLabel !== null) {
+      const menuPanelOptions = document.getElementsByClassName('ytp-panel-options')[0] as HTMLElement
+      menuPanelOptions.style.display = 'none'
 
-    const panelMenu = document.getElementsByClassName('ytp-panel-menu')[0] as HTMLElement
-    const toppingsSpeedItems = document.getElementsByClassName('tp-speeditem')
-    if (toppingsSpeedItems[0] === undefined) {
-      panelMenu.replaceChildren(...getPlaybackSpeedItems())
-      if (customPrecisionSpeedList.includes(currentSpeed)) {
-        const currentSpeedItem = document.querySelector(`#tp-${Number(currentSpeed) * 10000}x-speeditem`) as HTMLElement
-        if (currentSpeedItem !== null) {
-          currentSpeedItem.ariaChecked = 'true'
+      const panelMenu = document.getElementsByClassName('ytp-panel-menu')[0] as HTMLElement
+      const toppingsSpeedItems = document.getElementsByClassName('tp-speeditem')
+      if (toppingsSpeedItems[0] === undefined) {
+        panelMenu.replaceChildren(...getPlaybackSpeedItems())
+        if (customPrecisionSpeedList.includes(currentSpeed)) {
+          const currentSpeedItem = document.querySelector(`#tp-${Number(currentSpeed) * 10000}x-speeditem`) as HTMLElement
+          if (currentSpeedItem !== null) {
+            currentSpeedItem.ariaChecked = 'true'
+          }
+        } else {
+          customSpeedButton.style.display = ''
+          customSpeedButton.setAttribute('aria-checked', 'true')
+          const customSpeedItemLabel = customSpeedButton.querySelector('.ytp-menuitem-label') as HTMLElement
+          if (customSpeedItemLabel !== null) {
+            customSpeedItemLabel.textContent = `Custom(${Number(currentSpeed)})`
+          }
         }
       } else {
-        customSpeedButton.style.display = ''
-        customSpeedButton.setAttribute('aria-checked', 'true')
-        const customSpeedItemLabel = customSpeedButton.querySelector('.ytp-menuitem-label') as HTMLElement
-        if (customSpeedItemLabel !== null) {
-          customSpeedItemLabel.textContent = `Custom(${Number(currentSpeed)})`
+        for (const item of document.getElementsByClassName('tp-speeditem')) {
+          item.ariaChecked = 'false'
         }
-      }
-    } else {
-      for (const item of document.getElementsByClassName('tp-speeditem')) {
-        item.ariaChecked = 'false'
-      }
-      if (customPrecisionSpeedList.includes(currentSpeed)) {
-        const currentSpeedItem = document.querySelector(`#tp-${Number(currentSpeed) * 10000}x-speeditem`) as HTMLElement
-        if (currentSpeedItem !== null) {
-          currentSpeedItem.ariaChecked = 'true'
-        }
-      } else {
-        customSpeedButton.style.display = ''
-        customSpeedButton.setAttribute('aria-checked', 'true')
-        const customSpeedItemLabel = customSpeedButton.querySelector('.ytp-menuitem-label')
-        if (customSpeedItemLabel !== null) {
-          customSpeedItemLabel.textContent = `Custom(${Number(currentSpeed)})`
+        if (customPrecisionSpeedList.includes(currentSpeed)) {
+          const currentSpeedItem = document.querySelector(`#tp-${Number(currentSpeed) * 10000}x-speeditem`) as HTMLElement
+          if (currentSpeedItem !== null) {
+            currentSpeedItem.ariaChecked = 'true'
+          }
+        } else {
+          customSpeedButton.style.display = ''
+          customSpeedButton.setAttribute('aria-checked', 'true')
+          const customSpeedItemLabel = customSpeedButton.querySelector('.ytp-menuitem-label')
+          if (customSpeedItemLabel !== null) {
+            customSpeedItemLabel.textContent = `Custom(${Number(currentSpeed)})`
+          }
         }
       }
     }
-  }).catch((error) => {
-    console.error('Failed to load playback speed items:', error)
   })
 }
 
-const loadPlaybackSpeedMenu = async (): Promise<HTMLElement> => {
-  return await new Promise<HTMLElement>((resolve, reject) => {
+const loadPlaybackSpeedMenu = async (): Promise<Nullable<HTMLElement>> => {
+  return await new Promise<Nullable<HTMLElement>>((resolve, reject) => {
     const checkInterval = setInterval(() => {
       const firstMenuItemLabel = document.getElementsByClassName('ytp-menuitem-label')[0]
       const toppingsMenuItem = document.getElementsByClassName('tp-speeditem')[0]
-      if (firstMenuItemLabel?.textContent === '0.25' && toppingsMenuItem === undefined) {
-        clearInterval(checkInterval)
-        clearTimeout(checkTimeout)
-        resolve(firstMenuItemLabel as HTMLElement)
-      } else if (toppingsMenuItem !== undefined) {
+
+      if ((firstMenuItemLabel?.textContent === '0.25' && toppingsMenuItem === undefined) || toppingsMenuItem !== undefined) {
         clearInterval(checkInterval)
         clearTimeout(checkTimeout)
         resolve(firstMenuItemLabel as HTMLElement)
@@ -228,7 +222,11 @@ const loadPlaybackSpeedMenu = async (): Promise<HTMLElement> => {
 
     const checkTimeout = setTimeout(() => {
       clearInterval(checkInterval)
-      reject(new Error('Playback speeds not found within 2000ms.'))
+      if (process.env.NODE_ENV === 'development') {
+        const errorMessage = 'Playback speeds not found within 2000ms.'
+        console.warn(errorMessage)
+      }
+      resolve(null)
     }, 2000)
   })
 }
@@ -301,10 +299,10 @@ const useShortcuts = (event: KeyboardEvent): void => {
         changePlaybackSpeed(Number(toggleSpeed))
       }
     } else if (event.key === `${seekBackwardShortcut.toLowerCase()}`) {
-      player.seekCurrentTime('backward', +seekBackward)
+      (player as YTPlayer).seekCurrentTime('backward', +seekBackward)
       onDoubleTapSeek('back', seekBackward)
     } else if (event.key === `${seekForwardShortcut.toLowerCase()}`) {
-      player.seekCurrentTime('forward', +seekForward)
+      (player as YTPlayer).seekCurrentTime('forward', +seekForward)
       onDoubleTapSeek('forward', seekForward)
     } else if (event.key === `${increaseSpeedShortcut.toLowerCase()}`) {
       const increasedSpeed = Number((Number((+currentSpeed).toFixed(2)) + Number((+increaseSpeed).toFixed(2))).toFixed(2))
@@ -323,36 +321,38 @@ const useShortcuts = (event: KeyboardEvent): void => {
 }
 
 const onDoubleTapSeek = (dataSide: 'back' | 'forward', time: number): void => {
-  doubleTapSeekElement.setAttribute('data-side', dataSide)
-  doubleTapSeekElement.style.display = ''
-  const doubleTapSeekLabel = doubleTapSeekElement.querySelector('.ytp-doubletap-tooltip-label') as HTMLElement
-  if (doubleTapSeekLabel !== null) {
-    doubleTapSeekLabel.textContent = `${time} seconds`
-  }
-  const staticCircle = document.querySelector('.ytp-doubletap-static-circle') as HTMLElement
-  if (staticCircle !== null && dataSide === 'back') {
-    staticCircle.style.top = '50%'
-    staticCircle.style.left = '10%'
-    staticCircle.style.width = '110px'
-    staticCircle.style.height = '110px'
-    staticCircle.style.transform = 'translate(-14px, -40px)'
-  } else if (staticCircle !== null && dataSide === 'forward') {
-    staticCircle.style.top = '50%'
-    staticCircle.style.left = '80%'
-    staticCircle.style.width = '110px'
-    staticCircle.style.height = '110px'
-    staticCircle.style.transform = 'translate(-28px, -40px)'
-  }
-  clearTimeout(doubleTapSeekTimeout)
-  doubleTapSeekTimeout = setTimeout(() => {
-    doubleTapSeekElement.setAttribute('data-side', 'null')
-    doubleTapSeekElement.style.display = 'none'
-    const doubleTapLabel = doubleTapSeekElement.querySelector('.ytp-doubletap-tooltip-label')
-    if (doubleTapLabel !== null) {
-      doubleTapLabel.textContent = '5 seconds'
+  if (doubleTapSeekElement !== null) {
+    (doubleTapSeekElement).setAttribute('data-side', dataSide);
+    (doubleTapSeekElement).style.display = ''
+    const doubleTapSeekLabel = (doubleTapSeekElement).querySelector('.ytp-doubletap-tooltip-label') as HTMLElement
+    if (doubleTapSeekLabel !== null) {
+      doubleTapSeekLabel.textContent = `${time} seconds`
     }
-    staticCircle.style.cssText = 'null'
-  }, 500)
+    const staticCircle = document.querySelector('.ytp-doubletap-static-circle') as HTMLElement
+    if (staticCircle !== null && dataSide === 'back') {
+      staticCircle.style.top = '50%'
+      staticCircle.style.left = '10%'
+      staticCircle.style.width = '110px'
+      staticCircle.style.height = '110px'
+      staticCircle.style.transform = 'translate(-14px, -40px)'
+    } else if (staticCircle !== null && dataSide === 'forward') {
+      staticCircle.style.top = '50%'
+      staticCircle.style.left = '80%'
+      staticCircle.style.width = '110px'
+      staticCircle.style.height = '110px'
+      staticCircle.style.transform = 'translate(-28px, -40px)'
+    }
+    clearTimeout(doubleTapSeekTimeout)
+    doubleTapSeekTimeout = setTimeout(() => {
+      (doubleTapSeekElement as HTMLElement).setAttribute('data-side', 'null');
+      (doubleTapSeekElement as HTMLElement).style.display = 'none'
+      const doubleTapLabel = (doubleTapSeekElement as HTMLElement).querySelector('.ytp-doubletap-tooltip-label')
+      if (doubleTapLabel !== null) {
+        doubleTapLabel.textContent = '5 seconds'
+      }
+      staticCircle.style.cssText = 'null'
+    }, 500)
+  }
 }
 
 const changePlaybackSpeed = (speed: number): void => {
@@ -367,7 +367,7 @@ const changePlaybackSpeed = (speed: number): void => {
     }
   }
 
-  player.setPlaybackSpeed(speed)
+  (player as YTPlayer).setPlaybackSpeed(speed)
   currentSpeed = speed.toFixed(2)
 
   if (document.getElementsByClassName('tp-speeditem')[0] !== null) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
 		"allowJs": false,
 		"moduleResolution": "node",
 		"noEmitOnError": true,
-		"types": ["chrome-types"]
+		"types": ["chrome-types", "node"]
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 module.exports = {
+  mode: 'production',
   entry: {
     background: './src/scripts/background.ts',
     content: ['./src/scripts/core.ts', './src/scripts/index.ts'],


### PR DESCRIPTION
**Description**

The `loadElement` method, which is designed to wait and load an element, has been modified to fail silently and resolve with `null` instead of rejecting with an error. In `development` mode, developers will receive a warning.

**Changes Made**

- Adjusted the npm `build:prod` script to move `--mode production` from the command line to the configuration. Also, updated the `build:release` script to accommodate these changes.
- Updated the version of `@types/node`.
- Added a `Nullable` type to interfaces.
- Modified the `loadElement` function to fail silently, returning `null`, and providing a warning in development mode, rather than throwing an error.
- Adjusted `routeType/watch/main.ts` to account for the changes made to `loadElement` by using the `Nullable` type and issuing warnings instead of using try-catch blocks to handle errors.
- Added `node` types to `tsconfig.json`.