### PR TITLE
[youtube][bug]: Fix CSS style to make YouTube logo visible

### DIFF
--- a/src/content_scripts/modules/youtube/routes/playlist/index.css
+++ b/src/content_scripts/modules/youtube/routes/playlist/index.css
@@ -1,10 +1,5 @@
-/* General styling */
-* {
-	box-sizing: border-box;
-	transition: all 0.3s ease;
-}
-
 #toppings__metadata-toppings {
+	box-sizing: border-box;
 	height: fit-content;
 	border-radius: 8px;
 	background: rgba(101, 101, 101, 0.4);
@@ -13,6 +8,7 @@
 	font-family: 'Roboto', sans-serif;
 	padding: 12px 15px;
 	box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+	transition: all 0.3s ease;
 }
 
 div#toppings__toppings-header {


### PR DESCRIPTION
**Description:**

This pull request addresses an issue where a CSS style in the `src/content_scripts/modules/youtube/routes/playlist/index.css` file was causing the YouTube logo to be invisible. The problem stemmed from the use of a `*` selector, which unintentionally affected YouTube's styles, where the styles were meant to be applied only to extension-specific elements.

**Changes Made:**

- Removed the `*` selector from the CSS file, as it's considered a bad practice and can affect global styles.
- Reorganized and moved the affected styles to appropriate selectors, ensuring they only apply to the desired extension-specific elements.

**Testing:**

- Tested the changes to confirm that the YouTube logo is now visible without any unintended side effects.
- Verified that the corrected styles don't interfere with YouTube's standard logo visibility.

Resolves: #15
