### PR TITLE
[scripts]: Fix build and release scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": "true",
   "scripts": {
     "build:dev": "webpack --watch --config webpack.config.dev.js",
-    "build:prod": "webpack --watch",
-    "build:release": "webpack && node scripts/release.js",
+    "build:prod": "webpack",
+    "build:release": "npm run build:prod && node scripts/release.js",
     "lint": "eslint . --ext .ts --config .eslintrc.json --fix",
     "type-check": "tsc --noEmit",
     "test": "npm run lint && npm run type-check"

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const archiver = require('archiver');
 const path = require('path');
+const chalk = require('chalk');
 
 const buildDir = 'build';
 const outputZip = 'bundled.zip';
@@ -10,7 +11,23 @@ const archive = archiver('zip', { zlib: { level: 9 } });
 const output = fs.createWriteStream(outputZip);
 
 output.on('close', () => {
-	console.log(`${outputZip} created successfully.`);
+	console.clear();
+	const manifest = require('../src/manifest.json');
+	const extensionVersion = manifest.version;
+
+	const message = `
+  ┏---------------------------------┓
+  |                                 |
+  |      Build Version: ${extensionVersion}       |
+  |                                 |
+  ┗---------------------------------┛
+
+  Toppings has been successfully bundled and is ready for a new release.
+  You can now upload the '${outputZip}' file to the Chrome Web Store.
+  `;
+
+	console.log(chalk.blue(message));
+	process.exit(0);
 });
 
 archive.on('warning', (err) => {


### PR DESCRIPTION
**Description:**

This PR includes several improvements to the bundling script and build process for the Toppings extension. The changes are as follows:

1. **Updated Bundling Script:** The bundling script has been updated to display an elaborate message with the extension version and a visually appealing box art. The message informs that the extension has been successfully bundled and is ready for a new release. The script clears the terminal screen and exits with a success status code upon completion.

2. **Build Process:** The build process has been modified to separate the production build (`build:prod`) and the release build (`build:release`). The release build now depends on the production build, ensuring that the release is based on the latest production code.

**Changes Made:**

- Updated the bundling script to display a visually appealing and informative message.
- Separated the production build and release build scripts for clarity and consistency.

**Testing:**

Tested the updated bundling script and build process to ensure that the changes work as expected. Successfully bundled the extension and verified the appearance of the message.