### PR TITLE
[background][bug]: Fix extension refresh leads to extension website in development mode

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -6,7 +6,9 @@ const UNINSTALL_URL: string = 'https://grabtoppings.xyz/#/farewell'
 
 let toggleOn: boolean // Represents the current toggle state of the Toppings extension.
 
-void chrome.runtime.setUninstallURL(UNINSTALL_URL) // This URL will be redirected to when users uninstall the extension.
+if (process.env.NODE_ENV === 'production') {
+  void chrome.runtime.setUninstallURL(UNINSTALL_URL) // This URL will be redirected to when users uninstall the extension.
+}
 chrome.runtime.onInstalled.addListener(onInstallToppings) // Set up the extension when installed or updated.
 
 /**

--- a/src/background/onInstallToppings.ts
+++ b/src/background/onInstallToppings.ts
@@ -2,8 +2,9 @@ const INSTALL_URL: string = 'https://www.grabtoppings.xyz/#/greetings'
 
 const onInstallToppings = ({ reason }: { reason: chrome.runtime.OnInstalledReason }): void => {
   if (reason === 'install' || reason === 'update') {
-    // Open the install URL in a new tab
-    void chrome.tabs.create({ url: INSTALL_URL })
+    if (process.env.NODE_ENV === 'production') {
+      void chrome.tabs.create({ url: INSTALL_URL }) // This URL will be redirected to when extension is installed.
+    }
     // Define initial user preferences
     const initialPreferences = {
       // General


### PR DESCRIPTION
**Description:**
This PR fixes the issue where unnecessary redirection to extension websites occurred during development mode. The problem was by conditionally checking for `production` mode including the `chrome.runtime.setUninstallURL` and `chrome.tabs.create` functions based on the mode.

**Changes Made:**
- Modified the background script to conditionally invoke `chrome.runtime.setUninstallURL` only in the production environment to prevent unnecessary redirection during development.

- Conditionally included `chrome.tabs.create` only in the production environment to avoid redirection during installation while in development.

**Testing:**
- Tested the changes in both development and production environments to ensure proper functionality.
- Verified that redirection to extension websites no longer occurs during development mode.

**Resolves:** #21 