### PR TITLE
[components][playback-control]: Implementation for PlaybackControl component

### DIFF
--- a/src/content_scripts/components/PlaybackControl/PlaybackControlButton.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackControlButton.ts
@@ -1,0 +1,57 @@
+const PlaybackControlButton = (color = '#FFFFFF'): HTMLButtonElement => {
+  const button = document.createElement('button')
+  button.className = 'toppings__playback-control-button'
+  button.ariaHasPopup = 'true'
+  button.ariaLabel = 'Playback Control'
+  button.title = 'Playback Control'
+  button.style.backgroundColor = 'transparent'
+  button.style.border = 'none'
+  button.style.textAlign = 'inherit'
+  button.style.fontSize = '100%'
+  button.style.fontFamily = 'inherit'
+  button.style.color = 'white'
+  button.style.cursor = 'pointer'
+  button.style.padding = '0 2px'
+  button.style.height = '100%'
+  button.addEventListener('click', () => {
+    console.log('this should work')
+  })
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.setAttribute('height', '100%')
+  svg.setAttribute('viewBox', '0 0 24 24')
+  svg.setAttribute('fill', 'none')
+  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+
+  const paths = [
+    {
+      d: 'M4 14C4 12.9494 4.20693 11.9091 4.60896 10.9385C5.011 9.96793 5.60028 9.08601 6.34315 8.34314C7.08602 7.60028 7.96793 7.011 8.93853 6.60896C9.90914 6.20693 10.9494 6 12 6C13.0506 6 14.0909 6.20693 15.0615 6.60897C16.0321 7.011 16.914 7.60028 17.6569 8.34315C18.3997 9.08602 18.989 9.96793 19.391 10.9385C19.7931 11.9091 20 12.9494 20 14',
+      stroke: color,
+      strokeWidth: '1',
+      strokeLinejoin: 'round'
+    },
+    {
+      d: 'M10 15C10 14.7374 10.0517 14.4773 10.1522 14.2346C10.2528 13.992 10.4001 13.7715 10.5858 13.5858C10.7715 13.4001 10.992 13.2528 11.2346 13.1522C11.4773 13.0517 11.7374 13 12 13C12.2626 13 12.5227 13.0517 12.7654 13.1522C13.008 13.2528 13.2285 13.4001 13.4142 13.5858C13.5999 13.7715 13.7473 13.992 13.8478 14.2346C13.9483 14.4773 14 14.7374 14 15',
+      stroke: color,
+      strokeWidth: '1',
+      strokeLinejoin: 'round'
+    },
+    { d: 'M13 13L15 10', stroke: color, strokeWidth: '1', strokeLinecap: 'round', strokeLinejoin: 'round' },
+    { d: 'M20 14V15C20 15.5523 19.5523 16 19 16H5C4.44772 16 4 15.5523 4 15V14', stroke: color, strokeWidth: '1', strokeLinecap: 'round', strokeLinejoin: 'round' }
+  ]
+
+  paths.forEach((pathData) => {
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    path.setAttribute('d', pathData.d)
+    path.setAttribute('stroke', pathData.stroke ?? '')
+    path.setAttribute('stroke-width', pathData.strokeWidth ?? '')
+    path.setAttribute('stroke-linecap', pathData.strokeLinecap ?? '')
+    path.setAttribute('stroke-linejoin', pathData.strokeLinejoin ?? '')
+    svg.appendChild(path)
+  })
+  button.appendChild(svg)
+
+  return button
+}
+
+export default PlaybackControlButton

--- a/src/content_scripts/components/PlaybackControl/PlaybackControlButton.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackControlButton.ts
@@ -1,57 +1,48 @@
-const PlaybackControlButton = (color = '#FFFFFF'): HTMLButtonElement => {
-  const button = document.createElement('button')
-  button.className = 'toppings__playback-control-button'
-  button.ariaHasPopup = 'true'
-  button.ariaLabel = 'Playback Control'
-  button.title = 'Playback Control'
-  button.style.backgroundColor = 'transparent'
-  button.style.border = 'none'
-  button.style.textAlign = 'inherit'
-  button.style.fontSize = '100%'
-  button.style.fontFamily = 'inherit'
-  button.style.color = 'white'
-  button.style.cursor = 'pointer'
-  button.style.padding = '0 2px'
-  button.style.height = '100%'
-  button.addEventListener('click', () => {
-    console.log('this should work')
-  })
+import styles from './PlaybackControlButtonCSS'
 
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-  svg.setAttribute('height', '100%')
-  svg.setAttribute('viewBox', '0 0 24 24')
-  svg.setAttribute('fill', 'none')
-  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+const PlaybackControlButton = (iconColor = '#FFFFFF'): HTMLButtonElement => {
+  const PlaybackControlButton = document.createElement('button')
+  PlaybackControlButton.ariaHasPopup = 'true'
+  PlaybackControlButton.ariaLabel = 'Playback Control'
+  PlaybackControlButton.className = 'toppings__playback-control-button'
+  PlaybackControlButton.title = 'Playback Control'
+  PlaybackControlButton.appendChild(styles)
 
-  const paths = [
+  const controlButtonSVG = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  controlButtonSVG.setAttribute('fill', 'none')
+  controlButtonSVG.setAttribute('height', '100%')
+  controlButtonSVG.setAttribute('viewBox', '0 0 24 24')
+  controlButtonSVG.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+
+  const buttonSVGPaths = [
     {
       d: 'M4 14C4 12.9494 4.20693 11.9091 4.60896 10.9385C5.011 9.96793 5.60028 9.08601 6.34315 8.34314C7.08602 7.60028 7.96793 7.011 8.93853 6.60896C9.90914 6.20693 10.9494 6 12 6C13.0506 6 14.0909 6.20693 15.0615 6.60897C16.0321 7.011 16.914 7.60028 17.6569 8.34315C18.3997 9.08602 18.989 9.96793 19.391 10.9385C19.7931 11.9091 20 12.9494 20 14',
-      stroke: color,
+      stroke: iconColor,
       strokeWidth: '1',
       strokeLinejoin: 'round'
     },
     {
       d: 'M10 15C10 14.7374 10.0517 14.4773 10.1522 14.2346C10.2528 13.992 10.4001 13.7715 10.5858 13.5858C10.7715 13.4001 10.992 13.2528 11.2346 13.1522C11.4773 13.0517 11.7374 13 12 13C12.2626 13 12.5227 13.0517 12.7654 13.1522C13.008 13.2528 13.2285 13.4001 13.4142 13.5858C13.5999 13.7715 13.7473 13.992 13.8478 14.2346C13.9483 14.4773 14 14.7374 14 15',
-      stroke: color,
+      stroke: iconColor,
       strokeWidth: '1',
       strokeLinejoin: 'round'
     },
-    { d: 'M13 13L15 10', stroke: color, strokeWidth: '1', strokeLinecap: 'round', strokeLinejoin: 'round' },
-    { d: 'M20 14V15C20 15.5523 19.5523 16 19 16H5C4.44772 16 4 15.5523 4 15V14', stroke: color, strokeWidth: '1', strokeLinecap: 'round', strokeLinejoin: 'round' }
+    { d: 'M13 13L15 10', stroke: iconColor, strokeWidth: '1', strokeLinecap: 'round', strokeLinejoin: 'round' },
+    { d: 'M20 14V15C20 15.5523 19.5523 16 19 16H5C4.44772 16 4 15.5523 4 15V14', stroke: iconColor, strokeWidth: '1', strokeLinecap: 'round', strokeLinejoin: 'round' }
   ]
 
-  paths.forEach((pathData) => {
-    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
-    path.setAttribute('d', pathData.d)
-    path.setAttribute('stroke', pathData.stroke ?? '')
-    path.setAttribute('stroke-width', pathData.strokeWidth ?? '')
-    path.setAttribute('stroke-linecap', pathData.strokeLinecap ?? '')
-    path.setAttribute('stroke-linejoin', pathData.strokeLinejoin ?? '')
-    svg.appendChild(path)
+  buttonSVGPaths.forEach((path) => {
+    const buttonSVGPath = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    buttonSVGPath.setAttribute('d', path.d)
+    buttonSVGPath.setAttribute('stroke', path.stroke ?? 'initial')
+    buttonSVGPath.setAttribute('stroke-width', path.strokeWidth ?? 'initial')
+    buttonSVGPath.setAttribute('stroke-linecap', path.strokeLinecap ?? 'initial')
+    buttonSVGPath.setAttribute('stroke-linejoin', path.strokeLinejoin ?? 'initial')
+    controlButtonSVG.appendChild(buttonSVGPath)
   })
-  button.appendChild(svg)
+  PlaybackControlButton.appendChild(controlButtonSVG)
 
-  return button
+  return PlaybackControlButton
 }
 
 export default PlaybackControlButton

--- a/src/content_scripts/components/PlaybackControl/PlaybackControlButtonCSS.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackControlButtonCSS.ts
@@ -1,0 +1,19 @@
+const styles = document.createElement('style')
+
+const css = `
+    .toppings__playback-control-button {
+        background-color: transparent;
+        border: none;
+        text-align: inherit;
+        font-size: 100%;
+        font-family: inherit;
+        color: white;
+        cursor: pointer;
+        padding: 0 2px;
+        height: 100%;
+    }
+`
+
+styles.textContent = css
+
+export default styles

--- a/src/content_scripts/components/PlaybackControl/PlaybackControlButtonCSS.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackControlButtonCSS.ts
@@ -4,13 +4,14 @@ const css = `
     .toppings__playback-control-button {
         background-color: transparent;
         border: none;
+        outline: none;
         text-align: inherit;
         font-size: 100%;
         font-family: inherit;
         color: white;
         cursor: pointer;
         padding: 0 2px;
-        height: 100%;
+        width: 48px;
     }
 `
 

--- a/src/content_scripts/components/PlaybackControl/PlaybackControlMenu.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackControlMenu.ts
@@ -1,70 +1,25 @@
-const PlaybackControlButton = (color = '#FFFFFF'): HTMLButtonElement => {
-  // Create a button element
-  const button = document.createElement('button')
+import PlaybackMenuItems from './PlaybackMenuItems'
+import styles from './PlaybackControlMenuCSS'
 
-  // Create an SVG element
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-  svg.setAttribute('width', '24')
-  svg.setAttribute('height', '24')
-  svg.setAttribute('viewBox', '0 0 24 24')
-  svg.setAttribute('fill', 'none')
-  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+const PlaybackControlMenu = (videoPlayer: HTMLVideoElement, playbackRates: string[]): HTMLDivElement => {
+  const PlaybackControlMenu = document.createElement('div')
+  PlaybackControlMenu.className = 'toppings__playback-control-menu'
+  PlaybackControlMenu.appendChild(styles)
 
-  // Create path elements for the SVG
-  const createPath = (d: string): SVGPathElement => {
-    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
-    path.setAttribute('d', d)
-    path.setAttribute('stroke', color)
-    path.setAttribute('stroke-width', '2')
-    path.setAttribute('stroke-linejoin', 'round')
-    return path
-  }
+  const PlaybackPanel = document.createElement('div')
+  PlaybackPanel.className = 'toppings__playback-panel'
+  PlaybackControlMenu.appendChild(PlaybackPanel)
 
-  const path1 = createPath('M4 14C4 12.9494 4.20693 11.9091 4.60896 10.9385C5.011 9.96793 5.60028 9.08601 6.34315 8.34314C7.08602 7.60028 7.96793 7.011 8.93853 6.60896C9.90914 6.20693 10.9494 6 12 6C13.0506 6 14.0909 6.20693 15.0615 6.60897C16.0321 7.011 16.914 7.60028 17.6569 8.34315C18.3997 9.08602 18.989 9.96793 19.391 10.9385C19.7931 11.9091 20 12.9494 20 14')
+  const PlaybackPanelMenu = document.createElement('ul')
+  PlaybackPanelMenu.className = 'toppings__playback-panel-menu'
+  PlaybackPanelMenu.role = 'menu'
+  PlaybackPanel.appendChild(PlaybackPanelMenu)
+  PlaybackPanelMenu.append(...PlaybackMenuItems(videoPlayer, playbackRates))
 
-  const path2 = createPath('M10 15C10 14.7374 10.0517 14.4773 10.1522 14.2346C10.2528 13.992 10.4001 13.7715 10.5858 13.5858C10.7715 13.4001 10.992 13.2528 11.2346 13.1522C11.4773 13.0517 11.7374 13 12 13C12.2626 13 12.5227 13.0517 12.7654 13.1522C13.008 13.2528 13.2285 13.4001 13.4142 13.5858C13.5999 13.7715 13.7473 13.992 13.8478 14.2346C13.9483 14.4773 14 14.7374 14 15')
+  const currentRateItem = PlaybackPanelMenu.querySelector(`.toppings__playback-menu-button[data-rate='${videoPlayer.playbackRate}']`) ?? (document.querySelector('.toppings__playback-menu-button[data-rate=custom]') as HTMLElement)
+  currentRateItem.ariaChecked = 'true'
 
-  const path3 = createPath('M13 13L15 10')
-
-  const path4 = createPath('M20 14V15C20 15.5523 19.5523 16 19 16H5C4.44772 16 4 15.5523 4 15V14')
-
-  // Append path elements to the SVG
-  svg.appendChild(path1)
-  svg.appendChild(path2)
-  svg.appendChild(path3)
-  svg.appendChild(path4)
-
-  // Append the SVG to the button
-  button.appendChild(svg)
-
-  // Return the created button
-  return button
+  return PlaybackControlMenu
 }
 
-// const PlaybackControlButton = document.createElement('button')
-// PlaybackControlButton.className = 'styled-element'
-// PlaybackControlButton.ariaHasPopup = 'true'
-// // PlaybackControlButton.ariaControls = 'true'
-// PlaybackControlButton.ariaLabel = 'Playback Control'
-// PlaybackControlButton.title = 'Playback Control'
-
-// export default PlaybackControlButton
-
-// const styles = document.createElement('style')
-// styles.textContent = `
-//   .styled-element {
-//     background-color: transparent;
-//     border: none;
-//     text-align: inherit;
-//     font-size: 100%;
-//     font-family: inherit;
-//     color: white;
-//     cursor: pointer;
-//     padding: 0 2px;
-//     height: 100%;
-//   }
-// `
-// window.onload = () => {
-//   document.head.appendChild(styles)
-// }
-export default PlaybackControlButton
+export default PlaybackControlMenu

--- a/src/content_scripts/components/PlaybackControl/PlaybackControlMenu.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackControlMenu.ts
@@ -4,6 +4,7 @@ import styles from './PlaybackControlMenuCSS'
 const PlaybackControlMenu = (videoPlayer: HTMLVideoElement, playbackRates: string[]): HTMLDivElement => {
   const PlaybackControlMenu = document.createElement('div')
   PlaybackControlMenu.className = 'toppings__playback-control-menu'
+  PlaybackControlMenu.classList.add('hidden')
   PlaybackControlMenu.appendChild(styles)
 
   const PlaybackPanel = document.createElement('div')
@@ -14,10 +15,8 @@ const PlaybackControlMenu = (videoPlayer: HTMLVideoElement, playbackRates: strin
   PlaybackPanelMenu.className = 'toppings__playback-panel-menu'
   PlaybackPanelMenu.role = 'menu'
   PlaybackPanel.appendChild(PlaybackPanelMenu)
-  PlaybackPanelMenu.append(...PlaybackMenuItems(videoPlayer, playbackRates))
 
-  const currentRateItem = PlaybackPanelMenu.querySelector(`.toppings__playback-menu-button[data-rate='${videoPlayer.playbackRate}']`) ?? (document.querySelector('.toppings__playback-menu-button[data-rate=custom]') as HTMLElement)
-  currentRateItem.ariaChecked = 'true'
+  PlaybackPanelMenu.append(...PlaybackMenuItems(videoPlayer, playbackRates))
 
   return PlaybackControlMenu
 }

--- a/src/content_scripts/components/PlaybackControl/PlaybackControlMenu.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackControlMenu.ts
@@ -1,0 +1,70 @@
+const PlaybackControlButton = (color = '#FFFFFF'): HTMLButtonElement => {
+  // Create a button element
+  const button = document.createElement('button')
+
+  // Create an SVG element
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.setAttribute('width', '24')
+  svg.setAttribute('height', '24')
+  svg.setAttribute('viewBox', '0 0 24 24')
+  svg.setAttribute('fill', 'none')
+  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+
+  // Create path elements for the SVG
+  const createPath = (d: string): SVGPathElement => {
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    path.setAttribute('d', d)
+    path.setAttribute('stroke', color)
+    path.setAttribute('stroke-width', '2')
+    path.setAttribute('stroke-linejoin', 'round')
+    return path
+  }
+
+  const path1 = createPath('M4 14C4 12.9494 4.20693 11.9091 4.60896 10.9385C5.011 9.96793 5.60028 9.08601 6.34315 8.34314C7.08602 7.60028 7.96793 7.011 8.93853 6.60896C9.90914 6.20693 10.9494 6 12 6C13.0506 6 14.0909 6.20693 15.0615 6.60897C16.0321 7.011 16.914 7.60028 17.6569 8.34315C18.3997 9.08602 18.989 9.96793 19.391 10.9385C19.7931 11.9091 20 12.9494 20 14')
+
+  const path2 = createPath('M10 15C10 14.7374 10.0517 14.4773 10.1522 14.2346C10.2528 13.992 10.4001 13.7715 10.5858 13.5858C10.7715 13.4001 10.992 13.2528 11.2346 13.1522C11.4773 13.0517 11.7374 13 12 13C12.2626 13 12.5227 13.0517 12.7654 13.1522C13.008 13.2528 13.2285 13.4001 13.4142 13.5858C13.5999 13.7715 13.7473 13.992 13.8478 14.2346C13.9483 14.4773 14 14.7374 14 15')
+
+  const path3 = createPath('M13 13L15 10')
+
+  const path4 = createPath('M20 14V15C20 15.5523 19.5523 16 19 16H5C4.44772 16 4 15.5523 4 15V14')
+
+  // Append path elements to the SVG
+  svg.appendChild(path1)
+  svg.appendChild(path2)
+  svg.appendChild(path3)
+  svg.appendChild(path4)
+
+  // Append the SVG to the button
+  button.appendChild(svg)
+
+  // Return the created button
+  return button
+}
+
+// const PlaybackControlButton = document.createElement('button')
+// PlaybackControlButton.className = 'styled-element'
+// PlaybackControlButton.ariaHasPopup = 'true'
+// // PlaybackControlButton.ariaControls = 'true'
+// PlaybackControlButton.ariaLabel = 'Playback Control'
+// PlaybackControlButton.title = 'Playback Control'
+
+// export default PlaybackControlButton
+
+// const styles = document.createElement('style')
+// styles.textContent = `
+//   .styled-element {
+//     background-color: transparent;
+//     border: none;
+//     text-align: inherit;
+//     font-size: 100%;
+//     font-family: inherit;
+//     color: white;
+//     cursor: pointer;
+//     padding: 0 2px;
+//     height: 100%;
+//   }
+// `
+// window.onload = () => {
+//   document.head.appendChild(styles)
+// }
+export default PlaybackControlButton

--- a/src/content_scripts/components/PlaybackControl/PlaybackControlMenuCSS.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackControlMenuCSS.ts
@@ -1,0 +1,44 @@
+const styles = document.createElement('style')
+const css = `
+  .toppings__playback-control-menu {
+    display: none;
+    position: relative;
+    bottom: 335px;
+    left: 0px;
+    opacity: 0;
+    z-index: 9999;
+    animation: toppings__playback-control-menu-pop-in 100ms cubic-bezier(.2, 0, .38, .9) forwards;
+  }
+  
+  .toppings__playback-panel {
+    background: #2d2f31;
+    border: 1px solid #d1d7dc;
+    border-radius: 8px;
+    border-color: #3e4143;
+    min-height: 250px;
+    overflow-y: auto;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, .08), 0 4px 12px rgba(0, 0, 0, .08);
+  }
+  
+  .toppings__playback-panel-menu {
+    list-style: none;
+    padding: 0.8rem 0;
+    margin: 0;
+  }
+
+
+  @keyframes toppings__playback-control-menu-pop-in {
+    0% {
+        opacity: 0;
+        transform: scale(.9)
+    }
+
+    100% {
+        opacity: 1;
+        transform: scale(1)
+    }
+}
+`
+styles.textContent = css
+
+export default styles

--- a/src/content_scripts/components/PlaybackControl/PlaybackControlMenuCSS.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackControlMenuCSS.ts
@@ -1,29 +1,34 @@
 const styles = document.createElement('style')
 const css = `
   .toppings__playback-control-menu {
-    display: none;
+    display: initial;
     position: relative;
-    bottom: 335px;
-    left: 0px;
-    opacity: 0;
-    z-index: 9999;
-    animation: toppings__playback-control-menu-pop-in 100ms cubic-bezier(.2, 0, .38, .9) forwards;
   }
   
   .toppings__playback-panel {
+    position: absolute;
+    bottom: 64px;
+    right: 100%;
+    opacity: 0;
     background: #2d2f31;
     border: 1px solid #d1d7dc;
     border-radius: 8px;
     border-color: #3e4143;
     min-height: 250px;
-    overflow-y: auto;
+    z-index: 9999;
     box-shadow: 0 2px 4px rgba(0, 0, 0, .08), 0 4px 12px rgba(0, 0, 0, .08);
+    animation: toppings__playback-control-menu-pop-in 100ms cubic-bezier(.2, 0, .38, .9) forwards;
   }
   
   .toppings__playback-panel-menu {
     list-style: none;
-    padding: 0.8rem 0;
+    padding: 12px 0;
     margin: 0;
+    overflow-y: auto;
+  }
+
+  .hidden {
+    display: none;
   }
 
 

--- a/src/content_scripts/components/PlaybackControl/PlaybackMenuItem.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackMenuItem.ts
@@ -5,7 +5,7 @@ interface PlaybackMenuItemConfig {
   hasAriaChecked: string
   label: string
   onClick: (event: Event) => void
-  options?: (target: HTMLLIElement) => void
+  options?: (playbackMenuItem: HTMLLIElement) => void
 }
 
 const PlaybackMenuItem = (config: PlaybackMenuItemConfig): HTMLLIElement => {

--- a/src/content_scripts/components/PlaybackControl/PlaybackMenuItem.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackMenuItem.ts
@@ -1,0 +1,43 @@
+import styles from './PlaybackMenuItemCSS'
+
+interface PlaybackMenuItemConfig {
+  dataRate: string
+  hasAriaChecked: string
+  label: string
+  onClick: (event: Event) => void
+  options?: (target: HTMLLIElement) => void
+}
+
+const PlaybackMenuItem = (config: PlaybackMenuItemConfig): HTMLLIElement => {
+  const MenuListItem = document.createElement('li')
+  MenuListItem.className = 'toppings__playback-menu-item'
+  MenuListItem.setAttribute('role', 'none')
+  MenuListItem.addEventListener('click', config.onClick)
+  if (config.options !== undefined) {
+    config.options(MenuListItem)
+  }
+
+  const MenuItemButton = document.createElement('button')
+  MenuItemButton.className = 'toppings__playback-menu-button'
+  MenuItemButton.setAttribute('type', 'button')
+  MenuItemButton.setAttribute('role', 'menuitemradio')
+  MenuItemButton.setAttribute('tabindex', '-1')
+  MenuItemButton.setAttribute('aria-checked', config.hasAriaChecked)
+  MenuItemButton.setAttribute('data-rate', config.dataRate)
+  MenuListItem.appendChild(MenuItemButton)
+
+  const MenuButtonContent = document.createElement('div')
+  MenuButtonContent.className = 'toppings__playback-menu-button-content'
+  MenuItemButton.appendChild(MenuButtonContent)
+
+  const MenuContentValue = document.createElement('span')
+  MenuContentValue.className = 'toppings__playback-menu-content-value'
+  MenuContentValue.textContent = config.label
+  MenuButtonContent.appendChild(MenuContentValue)
+
+  MenuListItem.appendChild(styles)
+
+  return MenuListItem
+}
+
+export default PlaybackMenuItem

--- a/src/content_scripts/components/PlaybackControl/PlaybackMenuItemCSS.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackMenuItemCSS.ts
@@ -1,0 +1,60 @@
+const styles = document.createElement('style')
+const css = `
+.toppings__playback-menu-item {
+  position: relative;
+  padding-left: 0;
+  display: list-item;
+  list-style: none;
+}
+
+.toppings__playback-menu-button {
+  position: relative;
+  width: 100%;
+  height: auto;
+  min-width: auto;
+  padding: 0.8rem 0;
+  padding-left: 3.2rem;
+  padding-right: 3.2rem;
+  font: 400 1.4rem/1.4 sans-serif;
+  text-align: left;
+  white-space: nowrap;
+  display: flex;
+  align-items: flex-start;
+  cursor: pointer;
+  background: transparent;
+  color: white;
+  border: none;
+  vertical-align: bottom;
+  -webkit-user-select: none;
+}
+
+.toppings__playback-menu-button[aria-checked="true"]:after {
+  content: '';
+  display: block;
+  width: 0.8rem;
+  height: 0.8rem;
+  background: #a435f0;
+  border-radius: 50%;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 1.2rem;
+}
+
+.toppings__playback-menu-button-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  min-height: 1.96rem;
+  flex: 1;
+  min-width: 1px;
+}
+
+.toppings__playback-menu-content-value {
+  font-weight: 700;
+}  
+`
+styles.textContent = css
+
+export default styles

--- a/src/content_scripts/components/PlaybackControl/PlaybackMenuItemCSS.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackMenuItemCSS.ts
@@ -1,59 +1,65 @@
 const styles = document.createElement('style')
 const css = `
-.toppings__playback-menu-item {
-  position: relative;
-  padding-left: 0;
-  display: list-item;
-  list-style: none;
-}
+  .toppings__playback-menu-item {
+    position: relative;
+    padding-left: 0;
+    display: list-item;
+    list-style: none;
+  }
 
-.toppings__playback-menu-button {
-  position: relative;
-  width: 100%;
-  height: auto;
-  min-width: auto;
-  padding: 0.8rem 0;
-  padding-left: 3.2rem;
-  padding-right: 3.2rem;
-  font: 400 1.4rem/1.4 sans-serif;
-  text-align: left;
-  white-space: nowrap;
-  display: flex;
-  align-items: flex-start;
-  cursor: pointer;
-  background: transparent;
-  color: white;
-  border: none;
-  vertical-align: bottom;
-  -webkit-user-select: none;
-}
+  .toppings__playback-menu-button {
+    position: relative;
+    width: 100%;
+    height: auto;
+    min-width: auto;
+    margin: 0px !important;
+    padding: 12px 0;
+    padding-left: 51.2px;
+    padding-right: 51.2px;
+    font: 400 16px sans-serif;
+    text-align: left;
+    white-space: nowrap;
+    display: flex;
+    align-items: flex-start;
+    cursor: pointer;
+    background: transparent;
+    color: white;
+    border: none;
+    outline: none;
+    vertical-align: bottom;
+    -webkit-user-select: none;
+  }
 
-.toppings__playback-menu-button[aria-checked="true"]:after {
-  content: '';
-  display: block;
-  width: 0.8rem;
-  height: 0.8rem;
-  background: #a435f0;
-  border-radius: 50%;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  right: 1.2rem;
-}
+  .toppings__playback-menu-button[aria-checked="true"]:after {
+    content: '';
+    display: block;
+    width: 12px;
+    height: 12px;
+    background: rgba(59,130,246,.5);;
+    border-radius: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    right: 19.2px;
+  }
 
-.toppings__playback-menu-button-content {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.8rem;
-  min-height: 1.96rem;
-  flex: 1;
-  min-width: 1px;
-}
+  .toppings__playback-menu-button-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.8rem;
+    flex: 1;
+    min-height: 18px;
+    min-width: 1px;
+  }
 
-.toppings__playback-menu-content-value {
-  font-weight: 700;
-}  
+  .toppings__playback-menu-content-value {
+    font-weight: 700;
+  }
+
+  .hidden {
+    display: none;
+  }
 `
 styles.textContent = css
 

--- a/src/content_scripts/components/PlaybackControl/PlaybackMenuItems.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackMenuItems.ts
@@ -1,19 +1,20 @@
 import PlaybackMenuItem from './PlaybackMenuItem'
 
 const PlaybackMenuItems = (videoPlayer: HTMLVideoElement, playbackRates: string[]): HTMLElement[] => {
-  const CustomRateButton = PlaybackMenuItem({
-    dataRate: 'custom',
+  const CustomRateItem = PlaybackMenuItem({
+    dataRate: 'NaN',
     hasAriaChecked: 'false',
     label: 'Custom(NaN)',
-    onClick: () => {
-      changePlaybackRate(videoPlayer, 1)
+    onClick: (event) => {
+      changePlaybackRate(videoPlayer, Number(((event.currentTarget as HTMLElement).firstElementChild as HTMLElement).getAttribute('data-rate') as string))
     },
-    options: (customRateButton: HTMLElement) => {
-      customRateButton.style.display = 'none'
+    options: (customRateItem: HTMLElement) => {
+      customRateItem.classList.add('hidden')
+      customRateItem.setAttribute('data-custom', 'true')
     }
   })
 
-  const playbackRateItems = [CustomRateButton, ...playbackRates
+  const playbackRateItems = [CustomRateItem, ...playbackRates
     .sort((a, b) => Number(a) - Number(b))
     .map((playbackRate) => {
       return PlaybackMenuItem({
@@ -29,14 +30,19 @@ const PlaybackMenuItems = (videoPlayer: HTMLVideoElement, playbackRates: string[
   return playbackRateItems
 }
 
-const changePlaybackRate = (videoPlayer: HTMLVideoElement, playbackRate: number): void => {
-  const prevRateItem = document.querySelector('.toppings__playback-menu-button[aria-checked=true]') as HTMLElement
-  prevRateItem.ariaChecked = 'false'
+export const changePlaybackRate = (videoPlayer: HTMLVideoElement, playbackRate: number): void => {
+  const prevRateButton = document.querySelector('.toppings__playback-menu-button[aria-checked=true]') as HTMLElement
+  prevRateButton.ariaChecked = 'false'
 
   videoPlayer.playbackRate = playbackRate
 
-  const nextRateItem = document.querySelector(`.toppings__playback-menu-button[data-rate='${playbackRate}']`) ?? (document.querySelector('.toppings__playback-menu-item [data-rate=custom]') as HTMLElement)
-  nextRateItem.ariaChecked = 'true'
+  const nextRateButton = document.querySelector(`.toppings__playback-menu-button[data-rate='${playbackRate.toFixed(2)}']`) ?? (document.querySelector('.toppings__playback-menu-item[data-custom="true"]') as HTMLElement).firstElementChild as HTMLElement
+  if ((nextRateButton.parentElement as HTMLElement).getAttribute('data-custom') === 'true') {
+    (nextRateButton.querySelector('.toppings__playback-menu-content-value') as HTMLElement).textContent = `Custom(${playbackRate}x)`
+    nextRateButton.setAttribute('data-rate', playbackRate.toFixed(2));
+    (nextRateButton.parentElement as HTMLElement).classList.remove('hidden')
+  }
+  nextRateButton.ariaChecked = 'true'
 }
 
 export default PlaybackMenuItems

--- a/src/content_scripts/components/PlaybackControl/PlaybackMenuItems.ts
+++ b/src/content_scripts/components/PlaybackControl/PlaybackMenuItems.ts
@@ -1,0 +1,42 @@
+import PlaybackMenuItem from './PlaybackMenuItem'
+
+const PlaybackMenuItems = (videoPlayer: HTMLVideoElement, playbackRates: string[]): HTMLElement[] => {
+  const CustomRateButton = PlaybackMenuItem({
+    dataRate: 'custom',
+    hasAriaChecked: 'false',
+    label: 'Custom(NaN)',
+    onClick: () => {
+      changePlaybackRate(videoPlayer, 1)
+    },
+    options: (customRateButton: HTMLElement) => {
+      customRateButton.style.display = 'none'
+    }
+  })
+
+  const playbackRateItems = [CustomRateButton, ...playbackRates
+    .sort((a, b) => Number(a) - Number(b))
+    .map((playbackRate) => {
+      return PlaybackMenuItem({
+        dataRate: playbackRate,
+        hasAriaChecked: 'false',
+        label: `${Number(playbackRate)}x`,
+        onClick: () => {
+          changePlaybackRate(videoPlayer, Number(playbackRate))
+        }
+      })
+    })]
+
+  return playbackRateItems
+}
+
+const changePlaybackRate = (videoPlayer: HTMLVideoElement, playbackRate: number): void => {
+  const prevRateItem = document.querySelector('.toppings__playback-menu-button[aria-checked=true]') as HTMLElement
+  prevRateItem.ariaChecked = 'false'
+
+  videoPlayer.playbackRate = playbackRate
+
+  const nextRateItem = document.querySelector(`.toppings__playback-menu-button[data-rate='${playbackRate}']`) ?? (document.querySelector('.toppings__playback-menu-item [data-rate=custom]') as HTMLElement)
+  nextRateItem.ariaChecked = 'true'
+}
+
+export default PlaybackMenuItems

--- a/src/content_scripts/components/PlaybackControl/index.ts
+++ b/src/content_scripts/components/PlaybackControl/index.ts
@@ -1,42 +1,131 @@
 import PlaybackControlButton from './PlaybackControlButton'
 import PlaybackControlMenu from './PlaybackControlMenu'
+import { changePlaybackRate } from './PlaybackMenuItems'
 
-const DEFAULT_PLAYBACK_RATES = [
-  '0.25',
-  '0.5',
-  '0.75',
-  '1',
-  '1.25',
-  '1.5',
-  '1.75',
-  '2'
-]
+type Shortcuts = Record<string, { key: string, value: string }>
+type PlaybackRates = string[]
+
+interface ShortcutsEnabled {
+  enableShortcuts: true
+  shortcuts: Shortcuts
+}
+
+interface ShortcutsDisabled {
+  enableShortcuts: false
+}
+
+interface DefaultOptions extends ShortcutsEnabled {}
+
+type PlaybackControlOptions = DefaultOptions | ShortcutsDisabled
 
 class PlaybackControl {
+  private static readonly DEFAULT_PLAYBACK_RATES: PlaybackRates = [
+    '0.25',
+    '0.50',
+    '0.75',
+    '1.00',
+    '1.25',
+    '1.50',
+    '1.75',
+    '2.00'
+  ]
+
+  private static readonly DEFAULT_SHORTCUTS: Shortcuts = {
+    toggleSpeed: {
+      key: 'X',
+      value: '1.5'
+    },
+    seekBackward: {
+      key: 'A',
+      value: '15'
+    },
+    seekForward: {
+      key: 'D',
+      value: '15'
+    },
+    decreaseSpeed: {
+      key: 'S',
+      value: '0.25'
+    },
+    increaseSpeed: {
+      key: 'W',
+      value: '0.25'
+    }
+  }
+
   PlaybackControlButton: HTMLButtonElement
   PlaybackControlMenu: HTMLDivElement
 
   private readonly videoPlayer: HTMLVideoElement
 
-  constructor (videoPlayer?: HTMLVideoElement, playbackRates = DEFAULT_PLAYBACK_RATES) {
+  constructor (videoPlayer?: HTMLVideoElement, playbackRates: PlaybackRates = PlaybackControl.DEFAULT_PLAYBACK_RATES, options: PlaybackControlOptions = { enableShortcuts: true, shortcuts: PlaybackControl.DEFAULT_SHORTCUTS }) {
     this.videoPlayer = videoPlayer ?? document.querySelector('video') as HTMLVideoElement
     this.PlaybackControlButton = PlaybackControlButton()
     this.PlaybackControlMenu = PlaybackControlMenu(this.videoPlayer, playbackRates)
     this._connectedCallback()
+    if (options.enableShortcuts) {
+      this._enableShortcuts(options.shortcuts)
+    }
   }
 
   private _connectedCallback (): void {
-    this.PlaybackControlButton.addEventListener('click', this._toggleMenu.bind(this))
+    const currentRateItem = this.PlaybackControlMenu.querySelector('.toppings__playback-menu-button[data-rate=\'1.00\']') as HTMLElement
+    currentRateItem.ariaChecked = 'true'
+
+    this.PlaybackControlButton.addEventListener('click', () => {
+      const prevRateItem = document.querySelector('.toppings__playback-menu-button[aria-checked=true]') as HTMLElement
+      prevRateItem.ariaChecked = 'false'
+
+      const nextRateItem = document.querySelector(`.toppings__playback-menu-button[data-rate='${this.videoPlayer.playbackRate.toFixed(2)}']`) ?? (document.querySelector('.toppings__playback-menu-button[data-rate=custom]') as HTMLElement)
+      nextRateItem.ariaChecked = 'true'
+      this._toggleMenu()
+    })
 
     document.body.addEventListener('click', (event: Event) => {
-      if (!this.PlaybackControlMenu.contains(event.target as Node) && event.target !== this.PlaybackControlButton) {
-        this.PlaybackControlMenu.style.display = 'none'
+      if (!this.PlaybackControlMenu.classList.contains('hidden')) {
+        if (!this.PlaybackControlMenu.contains(event.target as Node) && event.target !== this.PlaybackControlButton) {
+          event.stopImmediatePropagation()
+          this.PlaybackControlMenu.classList.add('hidden')
+        }
       }
-    })
+    }, true)
   }
 
   private _toggleMenu (): void {
-    this.PlaybackControlMenu.style.display = (this.PlaybackControlMenu.style.display === 'none' || this.PlaybackControlMenu.style.display === '') ? 'initial' : 'none'
+    this.PlaybackControlMenu.classList.toggle('hidden')
+  }
+
+  private _enableShortcuts (shortcuts: Shortcuts): void {
+    document.addEventListener('keydown', (event: KeyboardEvent) => {
+      if (event.target !== null &&
+        (event.target as HTMLElement).tagName !== 'INPUT' &&
+        (event.target as HTMLElement).tagName !== 'TEXTAREA'
+      ) {
+        if (event.key === `${shortcuts.toggleSpeed.key.toLowerCase()}`) {
+          if (this.videoPlayer.playbackRate.toFixed(2) !== '1.00') {
+            changePlaybackRate(this.videoPlayer, 1)
+          } else {
+            changePlaybackRate(this.videoPlayer, Number(shortcuts.toggleSpeed.value))
+          }
+        } else if (event.key === `${shortcuts.seekBackward.key.toLowerCase()}`) {
+          this.videoPlayer.currentTime -= +shortcuts.seekBackward.value
+        } else if (event.key === `${shortcuts.seekForward.key.toLowerCase()}`) {
+          this.videoPlayer.currentTime += +shortcuts.seekForward.value
+        } else if (event.key === `${shortcuts.increaseSpeed.key.toLowerCase()}`) {
+          const increasedSpeed = Number((Number((+this.videoPlayer.playbackRate).toFixed(2)) + Number((+shortcuts.increaseSpeed.value).toFixed(2))).toFixed(2))
+          if (increasedSpeed > 16) {
+            return
+          }
+          changePlaybackRate(this.videoPlayer, increasedSpeed)
+        } else if (event.key === `${shortcuts.decreaseSpeed.key.toLowerCase()}`) {
+          const decreasedSpeed = Number((Number((+this.videoPlayer.playbackRate).toFixed(2)) - Number((+shortcuts.decreaseSpeed.value).toFixed(2))).toFixed(2))
+          if (decreasedSpeed < 0.0625) {
+            return
+          }
+          changePlaybackRate(this.videoPlayer, decreasedSpeed)
+        }
+      }
+    })
   }
 }
 

--- a/src/content_scripts/components/PlaybackControl/index.ts
+++ b/src/content_scripts/components/PlaybackControl/index.ts
@@ -1,0 +1,4 @@
+import PlaybackControlButton from './PlaybackControlButton'
+// import PlaybackControlMenu from './PlaybackControlMenu'
+
+export default PlaybackControlButton

--- a/src/content_scripts/components/PlaybackControl/index.ts
+++ b/src/content_scripts/components/PlaybackControl/index.ts
@@ -2,66 +2,41 @@ import PlaybackControlButton from './PlaybackControlButton'
 import PlaybackControlMenu from './PlaybackControlMenu'
 import { changePlaybackRate } from './PlaybackMenuItems'
 
-type Shortcuts = Record<string, { key: string, value: string }>
 type PlaybackRates = string[]
-
-interface ShortcutsEnabled {
-  enableShortcuts: true
-  shortcuts: Shortcuts
+type Shortcuts = Record<string, { key: string, value: string }>
+interface PlaybackControlOptions {
+  playbackRates?: PlaybackRates
+  enableShortcuts?: boolean
+  shortcuts?: Shortcuts
 }
-
-interface ShortcutsDisabled {
-  enableShortcuts: false
-}
-
-interface DefaultOptions extends ShortcutsEnabled {}
-
-type PlaybackControlOptions = DefaultOptions | ShortcutsDisabled
 
 class PlaybackControl {
-  private static readonly DEFAULT_PLAYBACK_RATES: PlaybackRates = [
-    '0.25',
-    '0.50',
-    '0.75',
-    '1.00',
-    '1.25',
-    '1.50',
-    '1.75',
-    '2.00'
-  ]
-
+  private static readonly DEFAULT_PLAYBACK_RATES: PlaybackRates = ['0.25', '0.50', '0.75', '1.00', '1.25', '1.50', '1.75', '2.00']
+  private static readonly DEFAULT_ENABLE_SHORTCUTS: true
   private static readonly DEFAULT_SHORTCUTS: Shortcuts = {
-    toggleSpeed: {
-      key: 'X',
-      value: '1.5'
-    },
-    seekBackward: {
-      key: 'A',
-      value: '15'
-    },
-    seekForward: {
-      key: 'D',
-      value: '15'
-    },
-    decreaseSpeed: {
-      key: 'S',
-      value: '0.25'
-    },
-    increaseSpeed: {
-      key: 'W',
-      value: '0.25'
-    }
+    toggleSpeed: { key: 'X', value: '1.5' },
+    seekBackward: { key: 'A', value: '15' },
+    seekForward: { key: 'D', value: '15' },
+    decreaseSpeed: { key: 'S', value: '0.25' },
+    increaseSpeed: { key: 'W', value: '0.25' }
   }
 
-  PlaybackControlButton: HTMLButtonElement
-  PlaybackControlMenu: HTMLDivElement
+  private static readonly DEFAULT_OPTIONS = {
+    playbackRates: PlaybackControl.DEFAULT_PLAYBACK_RATES,
+    enableShortcuts: PlaybackControl.DEFAULT_ENABLE_SHORTCUTS,
+    shortcuts: PlaybackControl.DEFAULT_SHORTCUTS
+  }
 
-  private readonly videoPlayer: HTMLVideoElement
+  public PlaybackControlButton: HTMLButtonElement
+  public PlaybackControlMenu: HTMLDivElement
 
-  constructor (videoPlayer?: HTMLVideoElement, playbackRates: PlaybackRates = PlaybackControl.DEFAULT_PLAYBACK_RATES, options: PlaybackControlOptions = { enableShortcuts: true, shortcuts: PlaybackControl.DEFAULT_SHORTCUTS }) {
-    this.videoPlayer = videoPlayer ?? document.querySelector('video') as HTMLVideoElement
+  constructor (private readonly videoPlayer: HTMLVideoElement, options: PlaybackControlOptions) {
+    options.playbackRates ??= PlaybackControl.DEFAULT_OPTIONS.playbackRates
+    options.enableShortcuts ??= PlaybackControl.DEFAULT_OPTIONS.enableShortcuts
+    options.shortcuts ??= PlaybackControl.DEFAULT_OPTIONS.shortcuts
+
     this.PlaybackControlButton = PlaybackControlButton()
-    this.PlaybackControlMenu = PlaybackControlMenu(this.videoPlayer, playbackRates)
+    this.PlaybackControlMenu = PlaybackControlMenu(this.videoPlayer, options.playbackRates)
     this._connectedCallback()
     if (options.enableShortcuts) {
       this._enableShortcuts(options.shortcuts)

--- a/src/content_scripts/components/PlaybackControl/index.ts
+++ b/src/content_scripts/components/PlaybackControl/index.ts
@@ -1,4 +1,43 @@
 import PlaybackControlButton from './PlaybackControlButton'
-// import PlaybackControlMenu from './PlaybackControlMenu'
+import PlaybackControlMenu from './PlaybackControlMenu'
 
-export default PlaybackControlButton
+const DEFAULT_PLAYBACK_RATES = [
+  '0.25',
+  '0.5',
+  '0.75',
+  '1',
+  '1.25',
+  '1.5',
+  '1.75',
+  '2'
+]
+
+class PlaybackControl {
+  PlaybackControlButton: HTMLButtonElement
+  PlaybackControlMenu: HTMLDivElement
+
+  private readonly videoPlayer: HTMLVideoElement
+
+  constructor (videoPlayer?: HTMLVideoElement, playbackRates = DEFAULT_PLAYBACK_RATES) {
+    this.videoPlayer = videoPlayer ?? document.querySelector('video') as HTMLVideoElement
+    this.PlaybackControlButton = PlaybackControlButton()
+    this.PlaybackControlMenu = PlaybackControlMenu(this.videoPlayer, playbackRates)
+    this._connectedCallback()
+  }
+
+  private _connectedCallback (): void {
+    this.PlaybackControlButton.addEventListener('click', this._toggleMenu.bind(this))
+
+    document.body.addEventListener('click', (event: Event) => {
+      if (!this.PlaybackControlMenu.contains(event.target as Node) && event.target !== this.PlaybackControlButton) {
+        this.PlaybackControlMenu.style.display = 'none'
+      }
+    })
+  }
+
+  private _toggleMenu (): void {
+    this.PlaybackControlMenu.style.display = (this.PlaybackControlMenu.style.display === 'none' || this.PlaybackControlMenu.style.display === '') ? 'initial' : 'none'
+  }
+}
+
+export default PlaybackControl

--- a/src/content_scripts/components/PlaybackControl/index.ts
+++ b/src/content_scripts/components/PlaybackControl/index.ts
@@ -12,7 +12,7 @@ interface PlaybackControlOptions {
 
 class PlaybackControl {
   private static readonly DEFAULT_PLAYBACK_RATES: PlaybackRates = ['0.25', '0.50', '0.75', '1.00', '1.25', '1.50', '1.75', '2.00']
-  private static readonly DEFAULT_ENABLE_SHORTCUTS: true
+  private static readonly DEFAULT_ENABLE_SHORTCUTS = true
   private static readonly DEFAULT_SHORTCUTS: Shortcuts = {
     toggleSpeed: { key: 'X', value: '1.5' },
     seekBackward: { key: 'A', value: '15' },
@@ -21,19 +21,13 @@ class PlaybackControl {
     increaseSpeed: { key: 'W', value: '0.25' }
   }
 
-  private static readonly DEFAULT_OPTIONS = {
-    playbackRates: PlaybackControl.DEFAULT_PLAYBACK_RATES,
-    enableShortcuts: PlaybackControl.DEFAULT_ENABLE_SHORTCUTS,
-    shortcuts: PlaybackControl.DEFAULT_SHORTCUTS
-  }
-
   public PlaybackControlButton: HTMLButtonElement
   public PlaybackControlMenu: HTMLDivElement
 
-  constructor (private readonly videoPlayer: HTMLVideoElement, options: PlaybackControlOptions) {
-    options.playbackRates ??= PlaybackControl.DEFAULT_OPTIONS.playbackRates
-    options.enableShortcuts ??= PlaybackControl.DEFAULT_OPTIONS.enableShortcuts
-    options.shortcuts ??= PlaybackControl.DEFAULT_OPTIONS.shortcuts
+  constructor (private readonly videoPlayer: HTMLVideoElement, options: PlaybackControlOptions = {}) {
+    options.playbackRates ??= PlaybackControl.DEFAULT_PLAYBACK_RATES
+    options.enableShortcuts ??= PlaybackControl.DEFAULT_ENABLE_SHORTCUTS
+    options.shortcuts ??= PlaybackControl.DEFAULT_SHORTCUTS
 
     this.PlaybackControlButton = PlaybackControlButton()
     this.PlaybackControlMenu = PlaybackControlMenu(this.videoPlayer, options.playbackRates)

--- a/src/content_scripts/components/index.ts
+++ b/src/content_scripts/components/index.ts
@@ -1,1 +1,3 @@
-export * from './PlaybackControl'
+import PlaybackControl from './PlaybackControl'
+
+export { PlaybackControl }

--- a/src/content_scripts/components/index.ts
+++ b/src/content_scripts/components/index.ts
@@ -1,0 +1,1 @@
+export * from './PlaybackControl'


### PR DESCRIPTION
## Description
This PR introduces the initial implementation of the "PlaybackControl" component. The objective is to create a reusable module for managing playback controls on video-centric websites, laying the groundwork for the broader "components" feature.

## Changes Made
- Added `PlaybackControl` class in `src/content_scripts/components/PlaybackControl/index.ts`.
- Implemented `PlaybackControlButton`, `PlaybackControlMenu`, and related functionalities.
- Introduced `PlaybackMenuItems`, `changePlaybackRate`, and associated modules.
- Created stylesheets for `PlaybackMenuItem`, `PlaybackControlMenu`, and `PlaybackControlButton`.

## Usage
To use the "Playback Control" component:
1. Import the component in your content script:
   ```typescript
   import { PlaybackControl } from './components';
   ```
2. Initialize a new instance of the `PlaybackControl` class:
   ```typescript
   const { PlaybackControlButton, PlaybackControlMenu } = new PlaybackControl(videoPlayer, playbackRates, options);
   ```
3. Insert the component at desired position:
   ```typescript
   const videoOptions = document.querySelector('.video-options');
   videoOptions.insertAdjacentElement('afterbegin', PlaybackControlButton);
   PlaybackControlButton.insertAdjacentElement('afterend', PlaybackControlMenu);
   ```

Resolves: #23 


