### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-web-ext.yml
+++ b/.github/workflows/build-web-ext.yml
@@ -9,6 +9,9 @@ on:
       - "web-ext/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build_firefox:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/enrych/toppings/security/code-scanning/3](https://github.com/enrych/toppings/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/build-web-ext.yml` at the workflow root (top-level), so it applies to both `build_firefox` and `build_chrome` jobs uniformly without changing behavior.

Best fix here:
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it after the trigger section (`on:` block) and before `jobs:`.

Why this is best:
- Minimal, least-privilege default that supports `actions/checkout`.
- No functional changes to existing build steps.
- Avoids duplicating permission config per job.

No imports, methods, or additional definitions are needed (YAML workflow only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
